### PR TITLE
Add Trust Graphic Tablet Widescreen (145f:0212)

### DIFF
--- a/UGTizer_GP0610/index.md
+++ b/UGTizer_GP0610/index.md
@@ -15,6 +15,7 @@ frame_controls: 6 buttons, 1 scroll "roller"
 sold_as:
     - iBall PF1064U
     - UGTizer GT1060
+    - Trust Graphic Tablet Widescreen (145f:0212)
 supported: true
 supported_in:
     digimend: ">= 6 (pen only - no frame controls)"


### PR DESCRIPTION
This looks physically equivalent to UGTizer GP0610 and even works with the same driver code.