### PR TITLE
Update index.md

### DIFF
--- a/Huion_HS610/index.md
+++ b/Huion_HS610/index.md
@@ -13,5 +13,7 @@ pen:
     pressure_levels: 8192
     tilt_detection: true
 frame_controls: 12 buttons, touch ring with a center button
+sold_as:
+    - Gaomon M10K Pro
 supported: false
 ---


### PR DESCRIPTION
Gaomon M10K Pro has 10 buttons instead of 12. For the rest behaves the same as the Huion HS610