### PR TITLE
Add Silvercrest GTA2000 rebrand info

### DIFF
--- a/Waltop_Media_Tablet_10.6_inch/index.md
+++ b/Waltop_Media_Tablet_10.6_inch/index.md
@@ -14,6 +14,7 @@ pen:
 sold_as:
     - Genius G-Pen M609
     - Genius G-Pen M609X
+    - Silvercrest GTA2000 aka SGT 10.6 A1/A2 aka DT53600
 maybe_sold_as:
     - iVista Media Tablet 10.6
     - Aiptek MediaTablet 10000u
@@ -39,6 +40,6 @@ volume
 the wheels control the sound volume, the buttons mute;
 
 brush  
-the wheels are supposed to control brush width in a graphics editor, the buttons do nothing.
+the wheels are supposed to control brush width in a graphics editor, the buttons do nothing (supposed: right-click and double left-click).
 
 

--- a/Waltop_Media_Tablet_10.6_inch/note.txt
+++ b/Waltop_Media_Tablet_10.6_inch/note.txt
@@ -1,1 +1,21 @@
 No response to buttons.
+
+The following information is based on the Silvercrest GTA2000 variant (aka Silvercrest SGT 10.6 A2), its manual and driver. (https://archive.org/details/silvercrest-driver)
+The official Windows driver has a tool ("Macrokey Manager") to reconfigure tablet K1-K26 buttons, wheels are not configurable, their defaults are:
+	Scroll mode:
+		Wheels: Scrolling (clock-wise - scroll down)
+		Wheel button: Switch between horizontal and vertical scrolling
+
+	Zoom mode:
+		Wheels: Zooming (clock-wise - zoom in)
+		Wheel button: Not assigned
+
+	Volume mode:
+		Wheels: System volume control (clock-wise - increase volume)
+		Wheel button: Toggle system sound on/off
+
+Further, there's a program that appears in the Control Panel of Windows that is used to configure the stylus: 
+	- pressure
+	- double-click distance
+	- both stylus buttons (defaults: bottom=right click; top=double left-click)
+	- working space selection (monitors or user-defined screen size, mode: pen or mouse)


### PR DESCRIPTION
Is it OK to add multiple names as "aka"?

I've seen two manuals, the current officially available manual refers to the model as "SGT 10.6 A1", on the rear the first ID is "GTA2000" (also second manual), the second rear ID being "DT53600" and the third "Targa N6 021105", whereas the driver available at archive.org apparently got the "SGT 10.6 A2" revision.

What a web.

Right now, I guess nobody's interested in USB traffic dumps of the accompaniying software? Maybe I'll get to implement that functionality one day, aka soon™