### PR TITLE
Huion Q-PAD listing

### DIFF
--- a/Waltop_Q_Pad/index.md
+++ b/Waltop_Q_Pad/index.md
@@ -13,6 +13,7 @@ pen:
 sold_as:
     - Aiptek HyperPen Mini
 maybe_sold_as:
+    - Huion Q-PAD460 
     - NGS Flexi Style
     - VisTablet PenPad
     - iVistaTablet Q Flex Pad


### PR DESCRIPTION
I Found a shop listing of the product here: https://product.pconline.com.cn/handinput/huion/478398.html

The model number was found on an archive snapshot of Huion's website: https://web.archive.org/web/20111205021950/http://www.huion-tablet.com/productshow.asp?id=45&mnid=5609&classname=%CA%FD%CE%BB%CA%D6%D0%B4%BB%E6%BB%AD%B0%E5&uppage=product.asp